### PR TITLE
Remove unreachable code

### DIFF
--- a/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
+++ b/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
@@ -5,7 +5,7 @@ import org.openkoreantext.processor.util.KoreanDictionaryProvider._
 import org.openkoreantext.processor.util.KoreanPos._
 
 /**
- * Stems Adjectives and Verbs: 새로운 스테밍을 추가했었다. -> 새롭다 + 스테밍 + 을 + 추가하다
+ * Stems Adjectives and Verbs: 새로운 스테밍을 추가했었다. -> 새롭다 + 스테밍 + 을 + 추가 + 하다
  */
 object KoreanStemmer {
   private val Endings = Set(Eomi, PreEomi)

--- a/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
+++ b/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
@@ -24,7 +24,7 @@ object KoreanStemmer {
       return tokens
     }
 
-    val stemmed = tokens.foldLeft(List[KoreanToken]()) {
+    tokens.foldLeft(List[KoreanToken]()) {
       case (l: List[KoreanToken], token: KoreanToken) if l.nonEmpty && Endings.contains(token.pos) =>
         if (Predicates.contains(l.head.pos)) {
           val prevToken = l.head
@@ -46,18 +46,5 @@ object KoreanStemmer {
         ) :: l
       case (l: List[KoreanToken], token: KoreanToken) => token :: l
     }.reverse
-
-    def validNounHeading(token: KoreanToken): Boolean = {
-      val heading = token.text.take(token.text.length - 2)
-
-      val validLength = token.text.length > 2
-      val validPos = token.pos == Verb
-      val validEndings = EndingsForNouns.contains(token.text.takeRight(2))
-      val validNouns = koreanDictionary.get(Noun).contains(heading)
-
-      validLength && validPos && validEndings && validNouns
-    }
-
-    stemmed.flatMap(token => Seq(token))
   }
 }

--- a/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
+++ b/src/main/scala/org/openkoreantext/processor/stemmer/KoreanStemmer.scala
@@ -58,16 +58,6 @@ object KoreanStemmer {
       validLength && validPos && validEndings && validNouns
     }
 
-    stemmed.flatMap {
-      case token if validNounHeading(token) =>
-        val heading = token.text.take(token.text.length - 2)
-        val ending = token.text.takeRight(2)
-
-        Seq(
-          KoreanToken(heading, Noun, token.offset, heading.length),
-          KoreanToken(ending, token.pos, token.offset + heading.length, token.length - heading.length)
-        )
-      case token => Seq(token)
-    }
+    stemmed.flatMap(token => Seq(token))
   }
 }

--- a/src/test/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizerTest.scala
+++ b/src/test/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Twitter Korean Text - Scala library to process Korean text
+ * Open Korean Text - Scala library to process Korean text
  *
  * Copyright 2014 Twitter, Inc.
  *


### PR DESCRIPTION
Due to change the logic, This code is unreachable now.
There is no verb and adjective like "~하다" in our dictionary.
In this case, It is recognized as "Noun + 하다".

This is confirmed by @nlpenguin 

Please leave some feedback!