### PR TITLE
Normalizer issue

### DIFF
--- a/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
+++ b/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
@@ -1,5 +1,5 @@
 /*
- * Twitter Korean Text - Scala library to process Korean text
+ * Open Korean Text - Scala library to process Korean text
  *
  * Copyright 2014 Twitter, Inc.
  *

--- a/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
+++ b/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
@@ -122,8 +122,7 @@ object KoreanNormalizer {
         (last == '데' || last == '가' || last == '지') &&
         koreanDictionary.get(Noun).contains(newHead)
     ) {
-      val mid = "인"
-      newHead + mid + last
+      newHead + "인" + last
     } else {
       chunk
     }

--- a/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
+++ b/src/main/scala/org/openkoreantext/processor/normalizer/KoreanNormalizer.scala
@@ -122,7 +122,7 @@ object KoreanNormalizer {
         (last == '데' || last == '가' || last == '지') &&
         koreanDictionary.get(Noun).contains(newHead)
     ) {
-      val mid = if (hc.vowel == 'ㅡ') "은" else "인"
+      val mid = "인"
       newHead + mid + last
     } else {
       chunk

--- a/src/test/scala/org/openkoreantext/processor/normalizer/KoreanNormalizerTest.scala
+++ b/src/test/scala/org/openkoreantext/processor/normalizer/KoreanNormalizerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Twitter Korean Text - Scala library to process Korean text
+ * Open Korean Text - Scala library to process Korean text
  *
  * Copyright 2014 Twitter, Inc.
  *

--- a/src/test/scala/org/openkoreantext/processor/normalizer/KoreanNormalizerTest.scala
+++ b/src/test/scala/org/openkoreantext/processor/normalizer/KoreanNormalizerTest.scala
@@ -70,6 +70,9 @@ class KoreanNormalizerTest extends TestBase {
   test("normalizeCodaN should normalize coda N nouns correctly") {
     assert(normalizeCodaN("오노딘가") === "오노디인가")
     assert(normalizeCodaN("소린가") === "소리인가")
+
+    assert(normalizeCodaN("버슨가") === "버스인가")
+    assert(normalizeCodaN("보슨지") === "보스인지")
     // Unknown noun
     assert(normalizeCodaN("쵸킨데") === "쵸킨데")
   }


### PR DESCRIPTION
It looks an unintended result.
  -은데, -은가, -은지
This was only unreachable code.
see following
	https://open-korean-text.herokuapp.com/normalize?text=버슨데
	{"strings":"버스은데"}
It  should be 버스인데.
