### PR TITLE
add a test for tokenizeTopN(text, n, profile)

### DIFF
--- a/src/test/java/org/openkoreantext/processor/OpenKoreanProcessorJavaTest.java
+++ b/src/test/java/org/openkoreantext/processor/OpenKoreanProcessorJavaTest.java
@@ -18,14 +18,14 @@
 
 package org.openkoreantext.processor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Test;
 import org.openkoreantext.processor.tokenizer.KoreanTokenizer;
 import org.openkoreantext.processor.tokenizer.Sentence;
 import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -97,6 +97,13 @@ public class OpenKoreanProcessorJavaTest {
             "받은(Verb(받다): 8, 2), 루루(Noun: 11, 2)]",
         OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, false).toString()
     );
+
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).getText(), "착한");
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).getStem(), "착하다");
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).getOffset(), 0);
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).getLength(), 2);
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).getPos(), KoreanPosJava.Adjective);
+    assertEquals(OpenKoreanTextProcessorJava.tokensToJavaKoreanTokenList(tokens, true).get(0).isUnknown(), false);
 
     text = "백여마리";
     tokens = OpenKoreanTextProcessorJava.tokenize(text);


### PR DESCRIPTION
to improve coverall coverage for: [tokenizeTopN(text, n, profile)](https://coveralls.io/builds/12289012/source?filename=src%2Fmain%2Fscala%2Forg%2Fopenkoreantext%2Fprocessor%2FOpenKoreanTextProcessor.scala#L94)