### PR TITLE
Add method to load dictionary resources to give option of eager loading

### DIFF
--- a/src/main/java/org/openkoreantext/processor/OpenKoreanTextProcessorJava.java
+++ b/src/main/java/org/openkoreantext/processor/OpenKoreanTextProcessorJava.java
@@ -178,4 +178,14 @@ public final class OpenKoreanTextProcessorJava {
   public static String detokenize(List<String> tokens) {
     return OpenKoreanTextProcessor.detokenize(JavaConverters.iterableAsScalaIterable(tokens));
   }
+
+  /**
+   * Load the dictionary resources into memory.
+   *
+   * Dictionary resources are loaded lazily by most API methods, however in some
+   * instances it is useful to be able to trigger this loading manually.
+   */
+  public static void loadResources() {
+    OpenKoreanTextProcessor.loadResources();
+  }
 }

--- a/src/main/scala/org/openkoreantext/processor/OpenKoreanTextProcessor.scala
+++ b/src/main/scala/org/openkoreantext/processor/OpenKoreanTextProcessor.scala
@@ -167,4 +167,20 @@ object OpenKoreanTextProcessor {
   def detokenize(tokens: Iterable[String]): String = {
     KoreanDetokenizer.detokenize(tokens)
   }
+
+  /**
+    * Load the dictionary resources into memory.
+    *
+    * Dictionary resources are loaded lazily by most API methods, however in some
+    * instances it is useful to be able to trigger this loading manually.
+    */
+  def loadResources():Unit = {
+    KoreanDictionaryProvider.koreanDictionary
+    KoreanDictionaryProvider.koreanEntityFreq
+    KoreanDictionaryProvider.spamNouns
+    KoreanDictionaryProvider.nameDictionary
+    KoreanDictionaryProvider.typoDictionaryByLength
+    KoreanDictionaryProvider.properNouns
+    KoreanDictionaryProvider.predicateStems
+  }
 }


### PR DESCRIPTION
Provide a ~~`loadDictionary`~~ `loadResources` method to easily allow pre-loading of the dictionary resources.

If there's anything I've missed, or you would prefer a different approach, please let me know.

As discussed in this feature request: https://github.com/open-korean-text/open-korean-text/issues/64