### PR TITLE
fix - memory leak on solutions hashmap

### DIFF
--- a/src/main/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizer.scala
+++ b/src/main/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizer.scala
@@ -163,10 +163,8 @@ object KoreanTokenizer {
     ) {
       val word = chunk.text.slice(start, end)
 
-      // Make sure the solutions hashmap won't have references to unused objects...
-      if (end > MAX_TRACE_BACK && start + 1 == end) {
-        solutions.remove(end - MAX_TRACE_BACK - 1)
-      }
+      // Removing unused solutions from solutions hashmap as the chunk is getting processed
+      removeUnusedSolutions(start, end, solutions)
 
       val curSolutions = solutions.get(start)
 
@@ -224,6 +222,14 @@ object KoreanTokenizer {
     }
 
     (directMatch ++ topCandidates).distinct
+  }
+
+  private[tokenizer] def removeUnusedSolutions(start: Int, end: Int, solutions: util.HashMap[Int, _]): util.HashMap[Int, _] = {
+    // Make sure the solutions hashmap won't have references to unused objects...
+    if (end > MAX_TRACE_BACK && start + 1 == end) {
+      solutions.remove(end - MAX_TRACE_BACK - 1)
+    }
+    return solutions;
   }
 
   private def findDirectMatch(chunk: KoreanToken): Seq[Seq[KoreanToken]] = {

--- a/src/main/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizer.scala
+++ b/src/main/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizer.scala
@@ -163,6 +163,11 @@ object KoreanTokenizer {
     ) {
       val word = chunk.text.slice(start, end)
 
+      // Make sure the solutions hashmap won't have references to unused objects...
+      if (end > MAX_TRACE_BACK && start + 1 == end) {
+        solutions.remove(end - MAX_TRACE_BACK - 1)
+      }
+
       val curSolutions = solutions.get(start)
 
       val candidates = curSolutions.flatMap {

--- a/src/test/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizerTest.scala
+++ b/src/test/scala/org/openkoreantext/processor/tokenizer/KoreanTokenizerTest.scala
@@ -18,6 +18,8 @@
 
 package org.openkoreantext.processor.tokenizer
 
+import java.util.HashMap
+
 import org.openkoreantext.processor.TestBase
 import org.openkoreantext.processor.tokenizer.KoreanTokenizer._
 import org.openkoreantext.processor.util.KoreanDictionaryProvider
@@ -273,5 +275,22 @@ class KoreanTokenizerTest extends TestBase {
     assert(tokenize("사랑로").mkString(" ") === "사랑(Noun: 0, 2) 로(Noun: 2, 1)")
 
     assert(tokenize("고화질로").mkString(" ") === "고화질(Noun: 0, 3) 로(Josa: 3, 1)")
+  }
+
+  test("test remove unused solutions") {
+    val unmodifiable = new HashMap[Int, String] { put(0, null); }
+
+    assert(removeUnusedSolutions(0, 1, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(0, 2, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(1, 3, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(1, 8, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(7, 8, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(8, 9, new HashMap[Int, String] { put(0, null); }).size() == 0)
+    assert(removeUnusedSolutions(9, 10, new HashMap[Int, String] { put(1, null); }).size() == 0)
+    assert(removeUnusedSolutions(10, 11, new HashMap[Int, String] { put(2, null); }).size() == 0)
+    assert(removeUnusedSolutions(299, 300, new HashMap[Int, String] { put(291, null); }).size() == 0)
+    assert(removeUnusedSolutions(298, 200, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(7, 10, unmodifiable).size() === 1)
+    assert(removeUnusedSolutions(9, 9, unmodifiable).size() === 1)
   }
 }


### PR DESCRIPTION
Fix memory leak on solutions hashmap.
Unused solutions were still being referenced from the solutions hashmap.

The main motivation is to remove old solutions after the algorithm moves to the next bunch of characters to analyze as they won't be accessed anymore in the data processing pipeline.

These unused references were creating tons of objects in the java memory heap as shared in https://github.com/open-korean-text/open-korean-text/issues/71#issuecomment-410179039 