### PR TITLE
add dist: trusty to use oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
  - "echo $JAVA_OPTS"
  - "export JAVA_OPTS=-Xmx512m"
 script: "[ ${TRAVIS_PULL_REQUEST} = 'false' ] && mvn -e clean deploy --settings settings.xml || mvn -e clean verify --settings settings.xml"
+dist: trusty
 jdk:
   - oraclejdk8
 branches:


### PR DESCRIPTION
I cannot sure that this change can use oraclejdk8 in travisCI, but I saw this issue on travis community [link](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038).
Could you try to apply this change to use travis CI correctly? 